### PR TITLE
Give tempfile suffix to match format

### DIFF
--- a/git-big-picture
+++ b/git-big-picture
@@ -924,7 +924,8 @@ def main(opts, args):
         # no output file requested, create a temporary one
         if not output_settings[OUT_FILE]:
             output_settings[OUT_FILE] = tempfile.NamedTemporaryFile(
-                    prefix='git-big-picture').name
+                    prefix='git-big-picture',
+                    suffix='.' + output_settings[FORMAT]).name
             debug("Created temp file: '%s'" % output_settings[OUT_FILE])
         debug("Writing to file: '%s'" % output_settings[OUT_FILE])
         write_to_file(output_settings[OUT_FILE], dot_output)


### PR DESCRIPTION
Google Chrome is no longer rendering SVGs as images without this change.